### PR TITLE
Fixed Inconsistent wait time

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -171,6 +171,6 @@ void mqtt_app_start(void *pvParameters) {
         msg_id = esp_mqtt_client_publish(client, topic, (char*)payload, stream.bytes_written, 0, 0);
         ESP_LOGI(LOGTYPE, "sent publish successful, msg_id=%d", msg_id);
 
-        vTaskDelay(pdMS_TO_TICKS(1000));
+        vTaskDelay(pdMS_TO_TICKS(10000));
     }
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -142,7 +142,7 @@ void mqtt_app_start(void *pvParameters) {
 
     // Wait for a second to collect enough samples
     if(msg_id == -2)
-        vTaskDelay(1000 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(1000));
     
     while(1) {
         // Setup Protobuf payload
@@ -163,7 +163,7 @@ void mqtt_app_start(void *pvParameters) {
 
         if(!pb_encode(&stream, QueueData_fields, &recordData)) {
             ESP_LOGE(LOGTYPE, "Failed to encode data");
-            vTaskDelay(5000 / portTICK_PERIOD_MS);
+            vTaskDelay(pdMS_TO_TICKS(5000));
             continue;
         }
 
@@ -171,6 +171,6 @@ void mqtt_app_start(void *pvParameters) {
         msg_id = esp_mqtt_client_publish(client, topic, (char*)payload, stream.bytes_written, 0, 0);
         ESP_LOGI(LOGTYPE, "sent publish successful, msg_id=%d", msg_id);
 
-        vTaskDelay(10000 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(1000));
     }
 }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -79,6 +79,6 @@ void display_write_queue(void *pvParameters) {
 			free(data.text);
 		}
 		else
-			vTaskDelay(30 / portTICK_PERIOD_MS);
+			vTaskDelay(pdMS_TO_TICKS(30));
 	}
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,6 +52,6 @@ void data_render(void *pvParameters) {
             display_write_page("Temp: ERR", 4, false);
             display_write_page("Humid: ERR", 5, false);
         }
-        vTaskDelay(1000 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(1000));
     }
 }

--- a/src/ntp.cpp
+++ b/src/ntp.cpp
@@ -25,7 +25,7 @@ void sync_systime() {
             break;
         }
         ESP_LOGI(TAG, "Waiting for time sync...");
-        vTaskDelay(2000 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(2000));
     }
     setenv("TZ", "UTC", 1);
 

--- a/src/tempSensorHandler.cpp
+++ b/src/tempSensorHandler.cpp
@@ -79,7 +79,7 @@ esp_err_t reg_write(uint8_t reg, uint8_t data) {
 // Reset the sensor data
 void reset_sensor() {
     reg_write(HDC2080_INIT_CONFIG_REG, 0x80);
-    vTaskDelay(portTICK_PERIOD_MS(50));
+    vTaskDelay(pdMS_TO_TICKS(50));
 }
 
 // Write standard configuration to the sensor

--- a/src/tempSensorHandler.cpp
+++ b/src/tempSensorHandler.cpp
@@ -79,7 +79,7 @@ esp_err_t reg_write(uint8_t reg, uint8_t data) {
 // Reset the sensor data
 void reset_sensor() {
     reg_write(HDC2080_INIT_CONFIG_REG, 0x80);
-    vTaskDelay(50 / portTICK_PERIOD_MS);
+    vTaskDelay(portTICK_PERIOD_MS(50));
 }
 
 // Write standard configuration to the sensor


### PR DESCRIPTION
Division by `portTICK_PERIOD_MS` causes the measurement to be sent twice (500ms apart) after running a while. Using `pdMS_TO_TICKS()` seems to fixed this issue.