### PR TITLE
Critical Bug patch

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -1,3 +1,4 @@
 
 void mqtt_init();
+void mqtt_reconnect();
 void mqtt_app_start(void *pvParameters);

--- a/include/wifi.h
+++ b/include/wifi.h
@@ -1,6 +1,4 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
-
-extern bool wifiConnected;
 void setup_wlan();

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -124,6 +124,11 @@ void mqtt_init() {
 
 }
 
+// Reconnect to the broker manually
+void mqtt_reconnect() {
+    esp_mqtt_client_reconnect(client);
+}
+
 // String Encoder for protobuf strings type
 bool encode_string(pb_ostream_t* stream, const pb_field_t* field, void* const* arg)
 {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -173,7 +173,7 @@ void mqtt_app_start(void *pvParameters) {
         }
 
         // Publish the message to the broker
-        msg_id = esp_mqtt_client_publish(client, topic, (char*)payload, stream.bytes_written, 0, 0);
+        msg_id = esp_mqtt_client_publish(client, topic, (char*)payload, stream.bytes_written, 1, 0);
         ESP_LOGI(LOGTYPE, "sent publish successful, msg_id=%d", msg_id);
 
         vTaskDelay(pdMS_TO_TICKS(10000));

--- a/src/wifi.cpp
+++ b/src/wifi.cpp
@@ -45,13 +45,11 @@ static void wifi_event_handler(void *event_handler_arg, esp_event_base_t event_b
     }
     case WIFI_EVENT_STA_DISCONNECTED:
         esp_wifi_connect();
-        wifiConnected = false;
         ESP_LOGI(LOGTYPE, "WiFi lost connection | reconnecting ... \n");
         display_write_page("WIFI: Disconn", 1, false);
         //display_write_page("Waiting IP...", 2, false);
         break;
     case IP_EVENT_STA_GOT_IP: {
-        wifiConnected = true;
         char ip_str[17];
         ESP_LOGI(LOGTYPE, "Device was assigned IP: %s\n", esp_ip4addr_ntoa(&((ip_event_got_ip_t *)event_data)->ip_info.ip, ip_str, sizeof(ip_str)));
         display_write_page("WIFI: Conn", 1, false);

--- a/src/wifi.cpp
+++ b/src/wifi.cpp
@@ -26,6 +26,13 @@ void init_on_connection()
 
     alreadyinit = true;
 }
+// This function will only invoke after the wifi has been successfully connected for the first time
+void reconnect_callback()
+{
+    if(!alreadyinit) return;
+
+    mqtt_reconnect();
+}
 
 static void wifi_event_handler(void *event_handler_arg, esp_event_base_t event_base, int32_t event_id, void *event_data)
 {
@@ -55,7 +62,8 @@ static void wifi_event_handler(void *event_handler_arg, esp_event_base_t event_b
         display_write_page("WIFI: Conn", 1, false);
         //display_write_page(ip_str, 2, false);
         if(!alreadyinit)
-            init_on_connection();
+            return init_on_connection();
+        reconnect_callback();
         break;
     } 
     default:

--- a/src/wifi.cpp
+++ b/src/wifi.cpp
@@ -56,7 +56,8 @@ static void wifi_event_handler(void *event_handler_arg, esp_event_base_t event_b
         ESP_LOGI(LOGTYPE, "Device was assigned IP: %s\n", esp_ip4addr_ntoa(&((ip_event_got_ip_t *)event_data)->ip_info.ip, ip_str, sizeof(ip_str)));
         display_write_page("WIFI: Conn", 1, false);
         //display_write_page(ip_str, 2, false);
-        init_on_connection();
+        if(!alreadyinit)
+            init_on_connection();
         break;
     } 
     default:


### PR DESCRIPTION
On wifi connection, some initializer function will call. Due to lack of checks, the function will be reinvoked if the wifi performs a reconnect.

Added control checks to prevent such issue from happening..